### PR TITLE
Ready for Review: SC2206 avoid

### DIFF
--- a/dlPVANetClass.sh
+++ b/dlPVANetClass.sh
@@ -33,7 +33,7 @@ startPage="https://www2.cead.ufv.br/sistemas/pvanet/"
 filesLink=$(grep "href=" "$fileToWork" | grep "download" | cut -d '=' -f2 | cut -d '/' -f2- | cut -d '"' -f1)
 
 # Convert in array
-filesLinkArray=( $filesLink )
+filesLinkArray=( "$filesLink" )
 
 # get the length of the array
 length=${#filesLinkArray[@]}

--- a/dlPVANetWork.sh
+++ b/dlPVANetWork.sh
@@ -35,9 +35,9 @@ filesLink=$(grep "href=\"../files/trabalhos/" "$fileToWork" | cut -d '=' -f5 | c
 fileToDL=$(echo "$filesLink" | rev | cut -d '/' -f1 | rev)
 
 # Convert in array
-matriculaArray=( $matricula )
-filesLinkArray=( $filesLink )
-fileToDLArray=( $fileToDL )
+matriculaArray=( "$matricula" )
+filesLinkArray=( "$filesLink" )
+fileToDLArray=( "$fileToDL" )
 
 
 


### PR DESCRIPTION
You are expanding a variable unquoted in an array. This will invoke the shell's sloppy word splitting and glob expansion.

Instead, prefer explicitly splitting (or not splitting):

If the variable should become a single array element, quote it.
If you want to split into lines or words, use mapfile, read -ra and/or while loops as appropriate.
This prevents the shell from doing unwanted splitting and glob expansion, and therefore avoiding problems with data containing spaces or special characters.