### PR TITLE
Ready for Review: SC2045 avoid

### DIFF
--- a/renameFiles.sh
+++ b/renameFiles.sh
@@ -31,13 +31,13 @@ if [ "$folderToWork" == '' ]; then
     echo -e "$RED\\nError: You need pass the folder to work"
 else
     echo -e "\n### Rename *.txt to .c ###\n"
-    for file in $(ls "$folderToWork"/*.txt); do 
+    for file in "$folderToWork"/*.txt; do 
         echo "$file to ${file::-4}.c"
         mv "$file" "${file::-4}.c"
     done
 
     echo -e "\n### Rename *.cpp to .c ###\n"
-    for file in $(ls "$folderToWork"/*.cpp); do 
+    for file in "$folderToWork"/*.cpp; do 
         echo "$file to ${file::-4}.c"
         mv "$file" "${file::-2}"
     done


### PR DESCRIPTION
Iterating over ls output is fragile. Use globs.

When looping over a set of files, it's always better to use globs when possible. Using command expansion causes word splitting and glob expansion, which will cause problems for certain filenames (typically first seen when trying to process a file with spaces in the name).